### PR TITLE
Add parameter for setting encoding type to use

### DIFF
--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -55,12 +55,14 @@ def read_pdf_table(input_path, **kwargs):
     if len(output) == 0:
         return
 
+    encoding = kwargs.get('encoding', 'utf-8')
+
     fmt = kwargs.get('format')
     if fmt == 'JSON':
-        return json.loads(output.decode('utf-8'))
+        return json.loads(output.decode(encoding))
 
     else:
-        return pd.read_csv(io.BytesIO(output))
+        return pd.read_csv(io.BytesIO(output), encoding = encoding)
 
 
 # Set alias for future rename from `read_pdf_table` to `read_pdf`


### PR DESCRIPTION
@chezou noticed I was unable to read in PDF files which used encoding other than 'utf-8'. Originally I was going to default to OS filesystem encoding. But I figured this would be more robust.