### PR TITLE
[Experimental] Add multiple_tables mode. close #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ See [example notebook](./examples/tabula_example.ipynb)
   - Same as `--outfile` option of tabula-java.
 - java_options (`list`, optional):
   - Set java options like `-Xmx256m`.
+- multiple_tables (bool, optional):
+  - (Experimental) Extract multiple tables. 
+  - This option uses JSON as an intermediate format, so if tabula-java output format will change, this option doesn't work.
 
 
 ## FAQ

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -158,11 +158,11 @@ def extract_from(raw_json):
 def localize_file(path):
     '''Ensure localize target file.
     
-    If the target file is URI, this function fetches into local storage.
+    If the target file is remote, this function fetches into local storage.
 
     Args:
         path (str):
-            File path or URI of target file.
+            File path or URL of target file.
     '''
 
     is_url = False

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -156,6 +156,15 @@ def extract_from(raw_json):
     return data_frames
 
 def localize_file(path):
+    '''Ensure localize target file.
+    
+    If the target file is URI, this function fetches into local storage.
+
+    Args:
+        path (str):
+            File path or URI of target file.
+    '''
+
     is_url = False
     try:
         pid = os.getpid()

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -46,6 +46,12 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertTrue(tabula.read_pdf(pdf_path, pages=1, java_options=['-Xmx256m']
                                        ).equals(pd.read_csv(expected_csv1)))
 
+    def test_read_pdf_for_multiple_tables(self):
+        pdf_path = 'tests/resources/data.pdf'
+        self.assertEqual(len(tabula.read_pdf(pdf_path, pages=2, multiple_tables=True)), 2)
+        with self.assertRaises(pd.parser.CParserError):
+            tabula.read_pdf(pdf_path, pages=2)
+
     def test_convert_from(self):
         pdf_path = 'tests/resources/data.pdf'
         expected_csv = 'tests/resources/data_1.csv'


### PR DESCRIPTION
This feature is experimental because this approach is not robust for
future changes of tabula-java.
Setting `multiple_tables` option, we can extract a list of DataFrames.