### PR TITLE
Handle markdown long description for Pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version='1.0.0',
     description='Simple wrapper for tabula, read tables from PDF into DataFrame',
     long_description=read_file('README.md'),
+    long_description_content_type="text/markdown",
     author=__author__,
     author_email='chezou@gmail.com',
     url='https://github.com/chezou/tabula-py',


### PR DESCRIPTION
Thanks for [PEP 566](https://www.python.org/dev/peps/pep-0566/#description-content-type-optional), as of [setuptools v38.6.0](http://setuptools.readthedocs.io/en/latest/history.html#v38-6-0), PyPI can render long description written in markdown.

This PR allows rendering markdown document on PyPI.

Tested on test.pypi.org: https://test.pypi.org/project/tabula-py/1.0.0/

Kudos: @aodag