### PR TITLE
adding tabula jar location via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ Replace `65001` and `UTF-8` appropriately, if the file encoding isn't UTF-8.
 
 You should escape file/directory name yourself.
 
+
+### I want to use a different tabula .jar  file
+You can specify the jar location via enviroment variable
+```bash
+export TABULA_JAR=".../tabula-x.y.z-jar-with-dependencies.jar"
+```
+
+
 ## Contributing
 
 Interested in helping out? I'd love to have your help!

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -29,6 +29,8 @@ TABULA_JAVA_VERSION = "1.0.2"
 JAR_NAME = "tabula-{}-jar-with-dependencies.jar".format(TABULA_JAVA_VERSION)
 JAR_DIR = os.path.abspath(os.path.dirname(__file__))
 JAR_PATH = os.path.join(JAR_DIR, JAR_NAME)
+if os.environ.get("TABULA_JAR"):
+    JAR_PATH = os.path.abspath(os.environ.get("TABULA_JAR"))
 
 JAVA_NOT_FOUND_ERROR = "`java` command is not found from this Python process. Please ensure Java is installed and PATH is set for `java`"
 


### PR DESCRIPTION
I added an option to read the location of the jar file from an environment variable, in case users would like to use a different .jar.