### PR TITLE
Clarifying first examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ tabula-py enables you to extract table from PDF into DataFrame and JSON. It also
 import tabula
 
 # Read pdf into DataFrame
-df = tabula.read_pdf("test.pdf", options)
+df = tabula.read_pdf("test.pdf", pages='all')
 
 # Read remote pdf into DataFrame
 df2 = tabula.read_pdf("https://github.com/tabulapdf/tabula-java/raw/master/src/test/resources/technology/tabula/arabic.pdf")
 
 # convert PDF into CSV
-tabula.convert_into("test.pdf", "output.csv", output_format="csv")
+tabula.convert_into("test.pdf", "output.csv", output_format="csv", pages='all')
 
 # convert all PDFs in a directory
-tabula.convert_into_by_batch("input_directory", output_format='csv')
+tabula.convert_into_by_batch("input_directory", output_format='csv', pages='all)
 ```
 
 See [example notebook](./examples/tabula_example.ipynb) for more detail. I also recommend to read [the tutorial article](https://aegis4048.github.io/parse-pdf-files-while-retaining-structure-with-tabula-py) written by [@aegis4048](https://github.com/aegis4048).


### PR DESCRIPTION
The examples are a bit confusing when testing tabula out for the first time - 
1. `options` is never instantiated, so it's unclear what's being specified.
2. The examples would only convert the first page, which is unexpected.

Hoping adding "pages='all'" should clarify it for newcomers.