### PR TITLE
Support Custom Output Paths for read_pdf

### DIFF
--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -79,7 +79,7 @@ def read_pdf(
     java_options=None,
     pandas_options=None,
     multiple_tables=False,
-    **kwargs
+    **kwargs,
 ):
     """Read tables in PDF.
 
@@ -152,7 +152,7 @@ def read_pdf(
     try:
         output = _run(java_options, kwargs, path, encoding)
         if not out_file:  # If we passed in an output path, pass it in
-            out_file = open(kwargs.get("output_path"), 'r')
+            out_file = open(kwargs.get("output_path"), "r")
     finally:
         if temporary:
             os.unlink(path)
@@ -196,7 +196,7 @@ def read_pdf_with_template(
     pandas_options=None,
     encoding="utf-8",
     java_options=None,
-    **kwargs
+    **kwargs,
 ):
     """Read tables in PDF.
 
@@ -227,7 +227,7 @@ def read_pdf_with_template(
             pandas_options=pandas_options,
             encoding=encoding,
             java_options=java_options,
-            **dict(kwargs, **option)
+            **dict(kwargs, **option),
         )
         if isinstance(_df, list):
             dataframes.extend(_df)


### PR DESCRIPTION
# Motivation

It looks like a recent change prevented an output path from being passed along to tabula.  There are usecases where we might want to keep the intermediate files later on.

# Changes

- Adds support for a custom `output_path` in `read_pdf`.  If no `output_path` is provided, the current behavior persists with a `namedtemporaryfile` being created (and presumably cleaned up during gc)