### PR TITLE
Read remote template for `read_pdf_with_template()`

### DIFF
--- a/tabula/file_util.py
+++ b/tabula/file_util.py
@@ -8,7 +8,7 @@ _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")
 
 
-def localize_file(path_or_buffer, user_agent=None):
+def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
     """Ensure localize target file.
 
     If the target file is remote, this function fetches into local storage.
@@ -16,6 +16,11 @@ def localize_file(path_or_buffer, user_agent=None):
     Args:
         path (str):
             File path or file like object or URL of target file.
+        user_agent (str, optional):
+            Set a custom user-agent when download a pdf from a url. Otherwise
+            it uses the default ``urllib.request`` user-agent.
+        suffix (str, optional):
+            File extension to check.
 
     Returns:
         (str, bool):
@@ -33,9 +38,9 @@ def localize_file(path_or_buffer, user_agent=None):
 
         parsed_url = parse_url(req.geturl())
         filename = os.path.basename(parsed_url.path)
-        if os.path.splitext(filename)[-1] != ".pdf":
+        if os.path.splitext(filename)[-1] != suffix:
             pid = os.getpid()
-            filename = "{0}.pdf".format(pid)
+            filename = "{}{}".format(pid, suffix)
 
         with open(filename, "wb") as f:
             shutil.copyfileobj(req, f)
@@ -44,7 +49,7 @@ def localize_file(path_or_buffer, user_agent=None):
 
     elif is_file_like(path_or_buffer):
         pid = os.getpid()
-        filename = "{0}.pdf".format(pid)
+        filename = "{}{}".format(pid, suffix)
 
         with open(filename, "wb") as f:
             shutil.copyfileobj(path_or_buffer, f)

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -98,8 +98,9 @@ def read_pdf(
     """Read tables in PDF.
 
     Args:
-        input_path (file_like_obj):
+        input_path (file_like_obj or str):
             File like object of tareget PDF file.
+            It can be URL, which is downloaded by tabula-py automatically.
         output_format (str, optional):
             Output format for returned object (``"dataframe" or ``"json"``)
         encoding (str, optional):
@@ -328,10 +329,12 @@ def read_pdf_with_template(
     """Read tables in PDF with a Tabula App template.
 
     Args:
-        input_path (file_like_obj):
+        input_path (file_like_obj or str):
             File like object of tareget PDF file.
-        template_path (file_like_obj):
+            It can be URL, which is downloaded by tabula-py automatically.
+        template_path (file_like_obj or str):
             File like object for Tabula app template.
+            It can be URL, which is downloaded by tabula-py automatically.
         pandas_options (dict, optional):
             Set pandas options like {'header': None}.
         encoding (str, optional):
@@ -350,6 +353,8 @@ def read_pdf_with_template(
 
 
     Examples:
+
+        You can use template file extracted by tabula app.
 
         >>> import tabula
         >>> tabula.read_pdf_with_template(pdf_path, "/path/to/data.tabula-template.json")

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -92,6 +92,7 @@ def read_pdf(
     java_options=None,
     pandas_options=None,
     multiple_tables=False,
+    user_agent=None,
     **kwargs
 ):
     """Read tables in PDF.
@@ -266,8 +267,6 @@ def read_pdf(
     if encoding == "utf-8":
         if not any("file.encoding" in opt for opt in java_options):
             java_options += ["-Dfile.encoding=UTF8"]
-
-    user_agent = kwargs.pop("user_agent", None)
 
     path, temporary = localize_file(input_path, user_agent)
 

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -219,6 +219,16 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertEqual(len(dfs), 4)
         self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
 
+    def test_read_pdf_with_remote_template(self):
+        template_path = (
+            "https://github.com/chezou/tabula-py/raw/master/"
+            "tests/resources/data.tabula-template.json"
+        )
+
+        dfs = tabula.read_pdf_with_template(self.pdf_path, template_path)
+        self.assertEqual(len(dfs), 4)
+        self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
+
     @patch("subprocess.check_output")
     @patch("tabula.wrapper._jar_path")
     def test_read_pdf_with_jar_path(self, jar_func, mock_fun):


### PR DESCRIPTION
`read_pdf_with_template()` works with remote URL.

```py
        template_path = (
            "https://github.com/chezou/tabula-py/raw/master/"
            "tests/resources/data.tabula-template.json"
        )

        dfs = tabula.read_pdf_with_template(pdf_path, template_path)
```