### PR TITLE
Use subprocess.run insted of check_output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+    - id: seed-isort-config
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    - id: isort
+  - repo: https://github.com/python/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python:
 - 3.6
 - 3.7
+- 3.8
 before_install:
 - pip install --upgrade setuptools
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,4 +59,4 @@ exclude =
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = pandas,numpy,distro
+known_third_party = nox,numpy,pandas,pkg_resources,setuptools,sphinx_rtd_theme

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -77,7 +77,16 @@ def _run(java_options, options, path=None, encoding="utf-8"):
         args.append(path)
 
     try:
-        return subprocess.check_output(args)
+        result = subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            check=True,
+        )
+        if result.stderr:
+            logger.warning("Got stderr: {}".format(result.stderr.decode(encoding)))
+        return result.stdout
     except FileNotFoundError:
         raise JavaNotFoundError(JAVA_NOT_FOUND_ERROR)
     except subprocess.CalledProcessError as e:

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -3,9 +3,10 @@ import json
 import os
 import platform
 import shutil
+import subprocess
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
@@ -229,7 +230,7 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertEqual(len(dfs), 4)
         self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
 
-    @patch("subprocess.check_output")
+    @patch("subprocess.run")
     @patch("tabula.wrapper._jar_path")
     def test_read_pdf_with_jar_path(self, jar_func, mock_fun):
         jar_func.return_value = "/tmp/tabula-java.jar"
@@ -248,7 +249,14 @@ class TestReadPdfTable(unittest.TestCase):
             "--guess",
             "tests/resources/data.pdf",
         ]
-        mock_fun.assert_called_with(target_args)
+        mock_fun.stdout = MagicMock(return_value=b"foo,bar\n1,2")
+        subp_args = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "stdin": subprocess.DEVNULL,
+            "check": True,
+        }
+        mock_fun.assert_called_with(target_args, **subp_args)
 
 
 if __name__ == "__main__":

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -249,7 +249,6 @@ class TestReadPdfTable(unittest.TestCase):
             "--guess",
             "tests/resources/data.pdf",
         ]
-        mock_fun.stdout = MagicMock(return_value=b"foo,bar\n1,2")
         subp_args = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,


### PR DESCRIPTION
This change gets subprocess.run back again. Also, this change introduces
stderr, and stdin option to subprocess.run to avoid error on Windows.

Close #187