### PR TITLE
Wrap Text / Row Configuration New Feature Request

### DIFF
--- a/wrap_text_feature
+++ b/wrap_text_feature
@@ -17,4 +17,4 @@ Another option would be to just say "wrap text" Yes/No where, if the text in a c
 Another option would be to specify the dimensions of a "typical" row size and the "maximum" row size, with the option to wrap text in a given way
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+

--- a/wrap_text_feature
+++ b/wrap_text_feature
@@ -1,0 +1,20 @@
+**Is your feature request related to a problem? Please describe.**
+On the PDF files that I have, the data is not always in a super clear format. There are times in which the text on the PDF is "wrapped" onto a second line. Therefore, when the file is exported to CSV, the data is inconsistent
+
+**Describe the solution you'd like**
+Within the function Tabula.Convert_into... there should be a function called "rows" where then user could configure that, for specific columns, you would specify the start point, end point, and number of rows
+Tabula would then convert the CSV into two rows for every instance where the text shows "Line Item" and "Item No" and ignore everything else. 
+In addition, the number of rows would force the conversion to wrap text in a certain number of rows. 
+
+The user would type something like this:
+columns = (1,2,3,4,5)
+start = ('Line Item%', '', '', '', '')
+end = ('Item No%', '%%', '', '', '')
+rows = 3 (or 1, depending on if you want the start row and end row included in the count)
+
+**Describe alternatives you've considered**
+Another option would be to just say "wrap text" Yes/No where, if the text in a column is at the edge, the next row of data would get wrapped 
+Another option would be to specify the dimensions of a "typical" row size and the "maximum" row size, with the option to wrap text in a given way
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
_Please let me know if this was submitted incorrectly. New to Github._ 

## Description
Added the Wrap Text Feature Request Document for review

## Motivation and Context
This solves the problem of PDF documents that don't have data in a clean format
This gives more flexibility for users to clean up data as part of the conversion to CSV

## How Has This Been Tested?
No

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22282824/70100275-21166a80-15e6-11ea-92cd-cd9cacd79f37.png)
^This screenshot is an example of the problem I'm facing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [ ] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

