### PR TITLE
Expose ability to change path of JAVA subprocess uses

### DIFF
--- a/tabula/__init__.py
+++ b/tabula/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
-from .util import environment_info
+from .util import environment_info, DEFAULT_JAVA_CONFIG
 from .wrapper import (
     convert_into,
     convert_into_by_batch,

--- a/tabula/util.py
+++ b/tabula/util.py
@@ -2,8 +2,15 @@
 Utility module providing some convinient functions.
 """
 
+import os
 import platform
 import warnings
+
+DEFAULT_JAVA_CONFIG = {"JAVA_PATH": 'java'}
+
+
+def _java_path():
+    return os.environ.get("JAVA_PATH", DEFAULT_JAVA_CONFIG["JAVA_PATH"])
 
 
 def deprecated(func):
@@ -42,7 +49,7 @@ def java_version():
     import subprocess
 
     try:
-        res = subprocess.check_output(["java", "-version"], stderr=subprocess.STDOUT)
+        res = subprocess.check_output([_java_path(), "-version"], stderr=subprocess.STDOUT)
         res = res.decode()
 
     except FileNotFoundError:

--- a/tabula/wrapper.py
+++ b/tabula/wrapper.py
@@ -32,7 +32,7 @@ import pandas as pd
 from .errors import CSVParseError, JavaNotFoundError
 from .file_util import localize_file
 from .template import load_template
-from .util import deprecated_option
+from .util import deprecated_option, _java_path
 
 logger = getLogger(__name__)
 
@@ -72,7 +72,7 @@ def _run(java_options, options, path=None, encoding="utf-8"):
         )
 
     built_options = build_options(options)
-    args = ["java"] + java_options + ["-jar", _jar_path()] + built_options
+    args = [_java_path()] + java_options + ["-jar", _jar_path()] + built_options
     if path:
         args.append(path)
 


### PR DESCRIPTION
## Description
Allow users to change the exact path and call to JAVA instead of relying on java being found by the system.

Add _java_path to util file
Use _java_path in main wrapper
Expose DEFAULT_JAVA_CONFIG to configure in program

## Motivation and Context
I could not get Python's subprocess to recognize the right path for JAVA.
Clearing the path, setting JAVA_HOME, uninstalling, reinstalling, deleting the registry key referenced below, nothing would work with python 3.6 32-bit.

Using `subprocess.call('java -version')` would return the error: 
```
Error: Registry key 'Software\JavaSoft\Java Runtime Environment'\CurrentVersion'
has value '1.8', but '1.7' is required.
Error: could not find java.dll
Error: Could not find Java SE Runtime Environment.
```

## How Has This Been Tested?
Setting both the environment variable JAVA_PATH or setting tabula.DEFAULT_JAVA_CONFIG['JAVA_PATH'] in the program works to allow the correct call to JAVA.

Specifically I could install the version of JAVA and set:
`tabula.DEFAULT_JAVA_CONFIG['JAVA_PATH'] = r"C:\Program Files (x86)\Java\jre1.8.0_231\bin\java.exe"`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [X] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
