### PR TITLE
Discard empty tables when parsing json results

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -645,6 +645,9 @@ def _extract_from(raw_json, pandas_options=None):
     columns, header_line_number = _convert_pandas_csv_options(pandas_options, columns)
 
     for table in raw_json:
+        if len(table["data"]) == 0:
+            continue
+
         list_data = [
             [np.nan if not e["text"] else e["text"] for e in row]
             for row in table["data"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes when scanning in lattice mode for tables empty results are generated. These results are not probably handled when parsing the raw-json result.
This patch skips such empty tables.

## Motivation and Context
Document: Intel SDM (https://software.intel.com/en-us/articles/intel-sdm), version October 2019, page 1496. 
When scanning the document in lattice mode, parsing of the results aborts by an IndexError "pop from empty list". This is caused by a call to pop() on list_data which is empty by definition of this bug. The patch skips tables in such cases.

## How Has This Been Tested?
Tested with the document above. This should be a non-breaking change since it has no effect on previously working cases. In every case where the patch skips/discards a table, the fixed but would have resulted in an IndexError due to the unconditional call to list_data.pop() which is empty by definition of the introduced branch condition.
Tests were run using nox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
