### PR TITLE
Added temp_directory argument for localize_file and functions that use it

### DIFF
--- a/tabula/file_util.py
+++ b/tabula/file_util.py
@@ -9,7 +9,7 @@ _VALID_URLS.discard("")
 MAX_FILE_SIZE = 250
 
 
-def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
+def localize_file(path_or_buffer, user_agent=None, suffix=".pdf", temp_directory=""):
     """Ensure localize target file.
 
     If the target file is remote, this function fetches into local storage.
@@ -22,6 +22,8 @@ def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
             it uses the default ``urllib.request`` user-agent.
         suffix (str, optional):
             File extension to check.
+        temp_directory (str, optional):
+            Directory to use for temporary files.
 
     Returns:
         (str, bool):
@@ -45,6 +47,7 @@ def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
         if ext != suffix:
             pid = os.getpid()
             filename = "{}{}".format(pid, suffix)
+        filename = os.path.join(temp_directory, filename)
 
         with open(filename, "wb") as f:
             shutil.copyfileobj(req, f)
@@ -52,7 +55,7 @@ def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
         return filename, True
 
     elif is_file_like(path_or_buffer):
-        filename = "{}{}".format(uuid.uuid4(), suffix)
+        filename = os.path.join(temp_directory, "{}{}".format(uuid.uuid4(), suffix))
 
         with open(filename, "wb") as f:
             shutil.copyfileobj(path_or_buffer, f)

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -102,6 +102,7 @@ def read_pdf(
     pandas_options=None,
     multiple_tables=True,
     user_agent=None,
+    temp_directory="",
     **kwargs
 ):
     """Read tables in PDF.
@@ -134,6 +135,8 @@ def read_pdf(
         user_agent (str, optional):
             Set a custom user-agent when download a pdf from a url. Otherwise
             it uses the default ``urllib.request`` user-agent.
+        temp_directory (str, optional):
+            Directory to use for temporary files.
         kwargs:
             Dictionary of option for tabula-java. Details are shown in
             :func:`build_options()`
@@ -303,7 +306,9 @@ def read_pdf(
         if not any("file.encoding" in opt for opt in java_options):
             java_options += ["-Dfile.encoding=UTF8"]
 
-    path, temporary = localize_file(input_path, user_agent)
+    path, temporary = localize_file(
+        input_path, user_agent, temp_directory=temp_directory
+    )
 
     if not os.path.exists(path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
@@ -356,6 +361,7 @@ def read_pdf_with_template(
     encoding="utf-8",
     java_options=None,
     user_agent=None,
+    temp_directory="",
     **kwargs
 ):
     """Read tables in PDF with a Tabula App template.
@@ -376,6 +382,8 @@ def read_pdf_with_template(
         user_agent (str, optional):
             Set a custom user-agent when download a pdf from a url. Otherwise
             it uses the default ``urllib.request`` user-agent.
+        temp_directory (str, optional):
+            Directory to use for temporary files.
         kwargs:
             Dictionary of option for tabula-java. Details are shown in
             :func:`build_options()`
@@ -472,7 +480,10 @@ def read_pdf_with_template(
     """  # noqa
 
     path, temporary = localize_file(
-        template_path, user_agent=user_agent, suffix=".json"
+        template_path,
+        user_agent=user_agent,
+        suffix=".json",
+        temp_directory=temp_directory,
     )
     options = load_template(path)
     dataframes = []
@@ -499,7 +510,12 @@ def read_pdf_with_template(
 
 
 def convert_into(
-    input_path, output_path, output_format="csv", java_options=None, **kwargs
+    input_path,
+    output_path,
+    output_format="csv",
+    java_options=None,
+    temp_directory="",
+    **kwargs
 ):
     """Convert tables from PDF into a file.
     Output file will be saved into `output_path`.
@@ -517,6 +533,8 @@ def convert_into(
 
             Example:
                 ``"-Xmx256m"``.
+        temp_directory (str, optional):
+            Directory to use for temporary files.
         kwargs:
             Dictionary of option for tabula-java. Details are shown in
             :func:`build_options()`
@@ -543,7 +561,7 @@ def convert_into(
 
     java_options = _build_java_options(java_options)
 
-    path, temporary = localize_file(input_path)
+    path, temporary = localize_file(input_path, temp_directory=temp_directory)
 
     if not os.path.exists(path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)


### PR DESCRIPTION
## Description
I added a `temp_directory` argument to control where exactly the temporary file is stored.

## Motivation and Context
The temporary file for `localize_file` was being stored locally without any explicit directory. This can cause an issue for users that don't have write access everywhere. 

## How Has This Been Tested?
I have not extensively tested, but I'm using my branch to solve a permission issue on my machine and it's working. I also ran the normal tests and they all passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
All the documentation changes are in the docstrings, so there are no changed files in docs/.
