### PR TITLE
New functionability in pandas_options using 'dtype':str

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -678,8 +678,13 @@ def _extract_from(raw_json, pandas_options=None):
 
         df = pd.DataFrame(data=list_data, columns=_columns, **pandas_options)
 
-        for c in df.columns:
-            df[c] = pd.to_numeric(df[c], errors="ignore")
+        if pandas_options.get('dtype', None) == str:
+            mask = df.applymap(lambda x: x == 'None')
+            for col in df.columns[(mask).any()]:
+                df.loc[mask[col], col] = None
+        else:
+            for c in df.columns:
+                df[c] = pd.to_numeric(df[c], errors="ignore") 
         data_frames.append(df)
 
     return data_frames


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes has been made in _extraxt_from method from io module allowing input in pandas_options the 'dtype'=str. Note that before these fixes you use pd.to_numeric in df.columns to force the dataframe be numeric, which didn't allow return the frame as a string. For instance, if 
pandas_options['dtype'] == str then don't force the numeric frame and parse the 'None' string values to None. See Figure 4.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> This fix gives the possibility to return the frame with string values without numeric issues. For example, if you have some data which uses European decimals like 1.321,21 and 112,21 and 1.421 then with pd.to_numeric the first two numbers return will be '1.321,21' and '112,21' because pandas couldn't force numeric. On the other hand, the return 1.421 in pd.to_numeric will be 1.421 but it should be 1421. The problem here is that pd.DataFrame don't have the parameter decimals unlike pd.read_csv.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> Tested using read_pdf_with_template with many crops. 
<!--- Include details of your testing environment, tests ran to see how --> In Figure 1 the multiplications of columns Quant with Valor unit (R$) must be the column Valor (R$), so I created a pytest environment to test if this operation works in many pdf's, with my fixes the tests passed for 24 tables.
<!--- your change affects other areas of the code, etc. --> My changes only affects when you're using multiple_tables=True (or read_pdf_with_template with multiple tables) and when the pandas_options 'dtype' key is str.

## Screenshots (if appropriate):
In the image, the Quant column 17.880 should be 17880 but with the pd.to_numeric it returns 17.88, see Figure 2 and compare with the fix in Figure 3: 
![Screenshot from 2020-02-20 18-32-56](https://user-images.githubusercontent.com/43217827/74980966-2d091000-5410-11ea-8f4f-46f09cf6e4b2.png)
Figure 1. Table in pdf.

Return without the fixes (using df.to_json() just for seing the dtypes):
![Screenshot from 2020-02-20 19-01-15](https://user-images.githubusercontent.com/43217827/74982712-68590e00-5413-11ea-91b4-c04add57afd0.png)
Figure 2. Returned df.to_json() without fixes.

Return with fixes (using df.to_json() just for seing the dtypes):
![Screenshot from 2020-02-20 18-58-20](https://user-images.githubusercontent.com/43217827/74982557-1adca100-5413-11ea-9d96-b9e3de2a7c10.png)
Figure 3. Returned df.to_json() with fixes.

In the follow image the changes which were made in the _extraxt_from method from io module:
![Screenshot from 2020-02-20 18-43-57](https://user-images.githubusercontent.com/43217827/74981418-fd0e3c80-5410-11ea-9edb-3ab029c53b57.png)
Figure 4. Changes in code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
