### PR TITLE
fixed the issue when passing the silent argument

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -62,7 +62,7 @@ def _run(java_options, options, path=None, encoding="utf-8"):
     """
     # Workaround to enforce the silent option. See:
     # https://github.com/tabulapdf/tabula-java/issues/231#issuecomment-397281157
-    if "silent" in options:
+    if options.get("silent"):
         java_options.extend(
             (
                 "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The silent argument behaves as intended after this bug fix.

## Description
<!--- Describe your changes in detail -->
Behaviour Now :=
* missing option: messages about font errors are outputted.
* `silent=True:` messages about font errors are NOT outputted.
* `silent=False:` messages about font errors are outputted.
* `silent=None:` messages about font errors are outputted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes the issue #246 .


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`nox`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
