### PR TITLE
fix bug in documentation

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -127,7 +127,7 @@ def read_pdf(
 
             Note:
                 With ``multiple_tables=True`` (default), pandas_options is passed
-                to pandas.read_csv, otherwise it is passed to pandas.DataFrame.
+                to pandas.DataFrame, otherwise it is passed to pandas.read_csv.
                 Those two functions are different for accept options like ``dtype``.
         multiple_tables (bool):
             It enables to handle multiple tables within a page. Default: ``True``


### PR DESCRIPTION
## Description
When `multiple_tables=True`, `pandas.DataFrame()` is used
When `multiple_tables=False`, `pandas.read_csv()` is used

This commit corrects a line that states the opposite

## Motivation and Context
In docstrings for `read_pdf` function, there are "note:" sections under both "pandas_options" and "multiple_tables" which contradict each other.
This commit resolves confusion due to the contradicting statements

## How Has This Been Tested?
`keep_default_na` is a parameter that is valid for `pandas.read_csv()` but not `pandas.DataFrame()`
When it is used ( in `pandas_options` of `read_pdf` function) with `multiple_tables=True`, an error occured and the traceback showed `pandas.DataFrame()` is being used. Setting `multiple_tables=False` fixed the error

Thus `pandas.DataFrame()` is used when`multiple_tables=True`

## Screenshots (if appropriate):
![Screenshot 2020-08-14 at 6 54 47 PM](https://user-images.githubusercontent.com/50870617/90254173-f9a7bb00-de5f-11ea-97e1-f036508c91cf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
