### PR TITLE
bump tabula-java to 1.0.4

### DIFF
--- a/tabula/errors/__init__.py
+++ b/tabula/errors/__init__.py
@@ -2,8 +2,7 @@ from pandas.errors import ParserError
 
 
 class CSVParseError(ParserError):
-    """Error represents CSV parse error, which mainly caused by pandas.
-    """
+    """Error represents CSV parse error, which mainly caused by pandas."""
 
     def __init__(self, message, cause):
         super(CSVParseError, self).__init__(message + ", caused by " + repr(cause))
@@ -11,7 +10,6 @@ class CSVParseError(ParserError):
 
 
 class JavaNotFoundError(Exception):
-    """Error represents Java doesn't exist.
-    """
+    """Error represents Java doesn't exist."""
 
     pass

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -36,7 +36,7 @@ from .template import load_template
 
 logger = getLogger(__name__)
 
-TABULA_JAVA_VERSION = "1.0.3"
+TABULA_JAVA_VERSION = "1.0.4"
 JAR_NAME = "tabula-{}-jar-with-dependencies.jar".format(TABULA_JAVA_VERSION)
 JAR_DIR = os.path.abspath(os.path.dirname(__file__))
 JAVA_NOT_FOUND_ERROR = (
@@ -692,7 +692,7 @@ def _extract_from(raw_json, pandas_options=None):
 
 
 def _convert_pandas_csv_options(pandas_options, columns):
-    """ Translate `pd.read_csv()` options into `pd.DataFrame()` especially for header.
+    """Translate `pd.read_csv()` options into `pd.DataFrame()` especially for header.
 
     Args:
         pandas_options (dict):

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -324,7 +324,7 @@ class TestReadPdfTable(unittest.TestCase):
         dfs = tabula.read_pdf(
             pdf_path, multiple_tables=True, pandas_options=pandas_options.copy()
         )
-        self.assertEqual(len(dfs), 4)
+        self.assertEqual(len(dfs), 5)
         self.assertTrue(dfs[0].equals(pd.read_csv(expected_csv, **pandas_options)))
 
         dfs_template = tabula.read_pdf_with_template(


### PR DESCRIPTION
## Description
Bump up tabula-java version to 1.0.4. See detail at https://github.com/tabulapdf/tabula-java/releases/tag/v1.0.4

## Motivation and Context
Will get better extraction

## How Has This Been Tested?
nox

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
