### PR TITLE
Ensure read binary from start of a file for read_pdf_with_template()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,6 @@ import os
 
 from setuptools import find_packages, setup
 
-setup(use_scm_version=True,)
+setup(
+    use_scm_version=True,
+)

--- a/tabula/file_util.py
+++ b/tabula/file_util.py
@@ -62,6 +62,7 @@ def localize_file(path_or_buffer, user_agent=None, suffix=".pdf"):
 
     elif is_file_like(path_or_buffer):
         filename = os.path.join(gettempdir(), "{}{}".format(uuid.uuid4(), suffix))
+        path_or_buffer.seek(0)
 
         with open(filename, "wb") as f:
             shutil.copyfileobj(path_or_buffer, f)

--- a/tabula/util.py
+++ b/tabula/util.py
@@ -42,23 +42,14 @@ def environment_info():
     from tabula import __version__
 
     print(
-        """Python version:
-    {}
+        f"""Python version:
+    {sys.version}
 Java version:
-    {}
-tabula-py version: {}
-platform: {}
+    {java_version().strip()}
+tabula-py version: {__version__}
+platform: {platform.platform()}
 uname:
-    {}
-linux_distribution: {}
-mac_ver: {}
-    """.format(
-            sys.version,
-            java_version().strip(),
-            __version__,
-            platform.platform(),
-            str(platform.uname()),
-            distro.linux_distribution(),
-            platform.mac_ver(),
-        )
+    {str(platform.uname())}
+linux_distribution: ('{distro.name()}', '{distro.version()}', '{distro.codename()}')
+mac_ver: {platform.mac_ver()}"""
     )

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -265,6 +265,15 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertEqual(len(dfs), 4)
         self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
 
+    def test_read_pdf_with_binary_template(self):
+        template_path = "tests/resources/data.tabula-template.json"
+
+        with open(self.pdf_path, "rb") as pdf:
+            with open(template_path, "rb") as template:
+                dfs = tabula.read_pdf_with_template(pdf, template)
+        self.assertEqual(len(dfs), 4)
+        self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
+
     @patch("subprocess.run")
     @patch("tabula.io._jar_path")
     def test_read_pdf_with_jar_path(self, jar_func, mock_fun):


### PR DESCRIPTION
## Description
Ensure reading binary from start for `read_pdf_with_template()`

Close https://github.com/chezou/tabula-py/issues/303

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
