### PR TITLE
Add use_raw_url option

### DIFF
--- a/tabula/file_util.py
+++ b/tabula/file_util.py
@@ -21,7 +21,10 @@ MAX_FILE_SIZE = 200
 
 
 def localize_file(
-    path_or_buffer: FileLikeObj, user_agent: Optional[str] = None, suffix: str = ".pdf"
+    path_or_buffer: FileLikeObj,
+    user_agent: Optional[str] = None,
+    suffix: str = ".pdf",
+    use_raw_url=False,
 ) -> Tuple[str, bool]:
     """Ensure localize target file.
 
@@ -35,6 +38,8 @@ def localize_file(
             it uses the default ``urllib.request`` user-agent.
         suffix (str, optional):
             File extension to check.
+        use_raw_url (bool):
+            Use `path_or_buffer` without quoting/dequoting.
 
     Returns:
         (str, bool):
@@ -46,7 +51,8 @@ def localize_file(
     safe_with_percent = "!#$%&'()*+,/:;=?@[]~"
 
     if _is_url(path_or_buffer):
-        path_or_buffer = quote(unquote(path_or_buffer), safe=safe_with_percent)
+        if not use_raw_url:
+            path_or_buffer = quote(unquote(path_or_buffer), safe=safe_with_percent)
         if user_agent:
             req = urlopen(_create_request(path_or_buffer, user_agent))
         else:

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -109,6 +109,7 @@ def read_pdf(
     pandas_options: Optional[Dict[str, Any]] = None,
     multiple_tables: bool = True,
     user_agent: Optional[str] = None,
+    use_raw_url: bool = False,
     **kwargs: str,
 ) -> Union[List[pd.DataFrame], Dict[str, Any]]:
     """Read tables in PDF.
@@ -119,6 +120,7 @@ def read_pdf(
             It can be URL, which is downloaded by tabula-py automatically.
         output_format (str, optional):
             Output format for returned object (``dataframe`` or ``json``)
+            Giving this option enforces to ignore `multiple_tables` option.
         encoding (str, optional):
             Encoding type for pandas. Default: ``utf-8``
         java_options (list, optional):
@@ -146,6 +148,9 @@ def read_pdf(
         user_agent (str, optional):
             Set a custom user-agent when download a pdf from a url. Otherwise
             it uses the default ``urllib.request`` user-agent.
+        use_raw_url (bool):
+            It enforces to use `input_path` string for url without quoting/dequoting.
+            Default: False
         kwargs:
             Dictionary of option for tabula-java. Details are shown in
             :func:`build_options()`
@@ -315,7 +320,7 @@ def read_pdf(
         if not any("file.encoding" in opt for opt in java_options):
             java_options += ["-Dfile.encoding=UTF8"]
 
-    path, temporary = localize_file(input_path, user_agent)
+    path, temporary = localize_file(input_path, user_agent, use_raw_url=use_raw_url)
 
     if not os.path.exists(path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
@@ -368,6 +373,7 @@ def read_pdf_with_template(
     encoding: str = "utf-8",
     java_options: Optional[List[str]] = None,
     user_agent: Optional[str] = None,
+    use_raw_url: bool = False,
     **kwargs: str,
 ) -> List[pd.DataFrame]:
     """Read tables in PDF with a Tabula App template.
@@ -388,6 +394,9 @@ def read_pdf_with_template(
         user_agent (str, optional):
             Set a custom user-agent when download a pdf from a url. Otherwise
             it uses the default ``urllib.request`` user-agent.
+        use_raw_url (bool):
+            It enforces to use `input_path` string for url without quoting/dequoting.
+            Default: False
         kwargs:
             Dictionary of option for tabula-java. Details are shown in
             :func:`build_options()`
@@ -484,7 +493,7 @@ def read_pdf_with_template(
     """  # noqa
 
     path, temporary = localize_file(
-        template_path, user_agent=user_agent, suffix=".json"
+        template_path, user_agent=user_agent, suffix=".json", use_raw_url=use_raw_url
     )
     options = load_template(path)
     dataframes = []


### PR DESCRIPTION
## Description
quote and dequote breaks S3 Presigned URL. This option ensures to use
original URL.

close #312

## Motivation and Context
Bug fix

## How Has This Been Tested?
Manual test:

```py
In [1]: import tabula

In [2]: fname = "https://tabula-py-test.s3.ca-central-1.amazonaws.com/data.pdf?response-content-disposition=inline&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEPr%2F%2F%2
   ...: F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJGMEQCICpTok5cRMxCpmU7GUs4lUW3i68%2Bwycq6xUoscS4AOlbAiAsqbFNV8NGmcjUUo0yTfiKKgFOK30TnFo%2BgexpwflhuSqZAghjEAMaDDYxND
   ...: MxNzc0OTUyMiIMuYhxgiv1fxOYUdbcKvYBtHgt6xnBM82hOXaL9NO%2BuVSmR9pV7LvjHIJC9XaR4QldC%2BM9RO%2FVuWeUHJ%2F87m0Zc5Vk0K0oY937xbiBUTiBcqb7hrJRWibHSha8OCucC%2FMwU%2
   ...: FQ8b5YUltSRbIBNw%2BQEx2zHufGySJsRoaeSkX32S22iXOrks8tt6qyFCkF7VgG50LLVVbt7%2B65jWkRZ22WT3MikBz5clh5OkKKG0Jv%2FpelgFS7iPF%2Fk5SR9Vy9PuAgtEyyFnEj%2Fjos7auYHJB
   ...: hYPgJXrcvTe2YLQGYHJA231NZOAX9UEC7h53TxUi1pJXwZVYWa5bS1iVvCTl9cqptftaEt3PYLMPH71JcGOuABXa%2FJjPCwIBUFH0ktkQKQq0TLvHwVTrH2ngX5Hvn%2Br2Vjmu1QLLAYRyWm7sMQgufGz
   ...: jOflCPezkteZUcezQacJ%2BlYoEC2vFnp1w5uRSRDiT%2BG28AcXqoIkguVRBXeboK2%2BeisyjJ4B%2FbG3rASyqV2%2BUSsTMCEoxDn%2FgHs2taGTHAVVXVChne7Q0pH5SDy4OHKopofXYIOiwEbWwvX
   ...: SgTVvMZLvz6v0336NvDVjJ3lZGq5GJQeKSkuNk40it1STe0tg%2FQHZMQ5m6HrGeYEHm2EONQNk9v0xJVJL2EKCET%2BwSg%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220811T174
   ...: 044Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=ASIAY6CBQ6UJKZWQ2TK2%2F20220811%2Fca-central-1%2Fs3%2Faws4_request&X-Amz-Signature=478368
   ...: 9af7d02a24a57bfaa67860f6d9524950a7ba046029e68bb012896ff395"

In [3]: tabula.read_pdf(fname, pages=1, use_raw_url=True)
Out[3]:
[     mpg  cyl   disp   hp  drat     wt   qsec  vs  am  gear
 0   21.0    6  160.0  110  3.90  2.620  16.46   0   1     4
 1   21.0    6  160.0  110  3.90  2.875  17.02   0   1     4
 2   22.8    4  108.0   93  3.85  2.320  18.61   1   1     4
 3   21.4    6  258.0  110  3.08  3.215  19.44   1   0     3
 4   18.7    8  360.0  175  3.15  3.440  17.02   0   0     3
 5   18.1    6  225.0  105  2.76  3.460  20.22   1   0     3
 6   14.3    8  360.0  245  3.21  3.570  15.84   0   0     3
 7   24.4    4  146.7   62  3.69  3.190  20.00   1   0     4
 8   22.8    4  140.8   95  3.92  3.150  22.90   1   0     4
 9   19.2    6  167.6  123  3.92  3.440  18.30   1   0     4
 10  17.8    6  167.6  123  3.92  3.440  18.90   1   0     4
 11  16.4    8  275.8  180  3.07  4.070  17.40   0   0     3
 12  17.3    8  275.8  180  3.07  3.730  17.60   0   0     3
 13  15.2    8  275.8  180  3.07  3.780  18.00   0   0     3
 14  10.4    8  472.0  205  2.93  5.250  17.98   0   0     3
 15  10.4    8  460.0  215  3.00  5.424  17.82   0   0     3
 16  14.7    8  440.0  230  3.23  5.345  17.42   0   0     3
 17  32.4    4   78.7   66  4.08  2.200  19.47   1   1     4
 18  30.4    4   75.7   52  4.93  1.615  18.52   1   1     4
 19  33.9    4   71.1   65  4.22  1.835  19.90   1   1     4
 20  21.5    4  120.1   97  3.70  2.465  20.01   1   0     3
 21  15.5    8  318.0  150  2.76  3.520  16.87   0   0     3
 22  15.2    8  304.0  150  3.15  3.435  17.30   0   0     3
 23  13.3    8  350.0  245  3.73  3.840  15.41   0   0     3
 24  19.2    8  400.0  175  3.08  3.845  17.05   0   0     3
 25  27.3    4   79.0   66  4.08  1.935  18.90   1   1     4
 26  26.0    4  120.3   91  4.43  2.140  16.70   0   1     5
 27  30.4    4   95.1  113  3.77  1.513  16.90   1   1     5
 28  15.8    8  351.0  264  4.22  3.170  14.50   0   1     5
 29  19.7    6  145.0  175  3.62  2.770  15.50   0   1     5
 30  15.0    8  301.0  335  3.54  3.570  14.60   0   1     5]
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
