### PR TITLE
fix type hints for readpdf kwargs

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -110,7 +110,7 @@ def read_pdf(
     multiple_tables: bool = True,
     user_agent: Optional[str] = None,
     use_raw_url: bool = False,
-    **kwargs: str,
+    **kwargs,
 ) -> Union[List[pd.DataFrame], Dict[str, Any]]:
     """Read tables in PDF.
 
@@ -374,7 +374,7 @@ def read_pdf_with_template(
     java_options: Optional[List[str]] = None,
     user_agent: Optional[str] = None,
     use_raw_url: bool = False,
-    **kwargs: str,
+    **kwargs,
 ) -> List[pd.DataFrame]:
     """Read tables in PDF with a Tabula App template.
 
@@ -524,7 +524,7 @@ def convert_into(
     output_path: str,
     output_format: str = "csv",
     java_options: Optional[List[str]] = None,
-    **kwargs: str,
+    **kwargs,
 ) -> None:
     """Convert tables from PDF into a file.
     Output file will be saved into `output_path`.
@@ -589,7 +589,7 @@ def convert_into_by_batch(
     input_dir: str,
     output_format: str = "csv",
     java_options: Optional[List[str]] = None,
-    **kwargs: str,
+    **kwargs,
 ) -> None:
     """Convert tables from PDFs in a directory.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR removes the incorrect type hint `str` of the `kwargs` parameter of `tabula.readpdf`.
The `kwargs` ultimatly get trought to `build_options` and not all of them are of type `str`.
Explanation from the docs of [PEP 484 – Type Hints # Arbitrary argument lists and default argument values](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values):
> 
> ```python
> def foo(*args: str, **kwds: int): ...
> ```
> 
> is acceptable and it means that, e.g., all of the following represent function calls with valid types of arguments:
> ```python
> foo('a', 'b', 'c')
> foo(x=1, y=2)
> foo('', z=0)
> ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

my mypy analysis reported errors with my use of the `tabula.read_pdf` function
```
tabula.read_pdf([...], pages=[1, 2], lattice=True)
error: Argument "pages" to "read_pdf" has incompatible type "List[int]"; expected "str"  [arg-type]
error: Argument "lattice" to "read_pdf" has incompatible type "bool"; expected "str"  [arg-type]
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

In my local virtualenv I modified the file `tabula/io.py` according to the change of this PR.
Afterwars ran the mypy check again and the errors were gone.

I also considered explicitly declaring `**kwargs: Any`, but according to the docs that seemed to be redundant to just leaving out the type hint.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
