### PR TITLE
fix: do not break pandas_options

### DIFF
--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -160,12 +160,13 @@ class TestReadPdfTable(unittest.TestCase):
                 self.pdf_path, pages=1, stream=True, pandas_options={"header": "infer"}
             )[0].equals(pd.read_csv(self.expected_csv1, header="infer"))
         )
+        p_opts = {"header": "infer", "names": column_name}
         self.assertTrue(
             tabula.read_pdf(
                 self.pdf_path,
                 pages=1,
                 stream=True,
-                pandas_options={"header": "infer", "names": column_name},
+                pandas_options=p_opts,
             )[0].equals(
                 pd.read_csv(self.expected_csv1, header="infer", names=column_name)
             )
@@ -176,7 +177,7 @@ class TestReadPdfTable(unittest.TestCase):
                 pages=1,
                 stream=True,
                 multiple_tables=True,
-                pandas_options={"header": "infer", "names": column_name},
+                pandas_options=p_opts,
             )[0].equals(
                 pd.read_csv(self.expected_csv1, header="infer", names=column_name)
             )
@@ -187,7 +188,7 @@ class TestReadPdfTable(unittest.TestCase):
                 pages=1,
                 stream=True,
                 multiple_tables=True,
-                pandas_options={"header": "infer", "columns": column_name},
+                pandas_options=p_opts,
             )[0].equals(
                 pd.read_csv(self.expected_csv1, header="infer", names=column_name)
             )


### PR DESCRIPTION
## Description
Fix #338

## Motivation and Context
`pandas_options` option should be immutable. This fix allows to reuse `pandas_options` multiple times. 

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
