### PR TITLE
Permit specifying relative_area in template

### DIFF
--- a/tabula/template.py
+++ b/tabula/template.py
@@ -78,8 +78,14 @@ def _convert_template_option(
         round(cast(float, template["y2"]), 3),
         round(cast(float, template["x2"]), 3),
     ]
+    relative_area = cast(bool, template.get("relative_area"))
     option = TabulaOption(
-        guess=guess, lattice=lattice, stream=stream, pages=pages, area=area
+        guess=guess,
+        lattice=lattice,
+        stream=stream,
+        pages=pages,
+        area=area,
+        relative_area=relative_area,
     )
 
     return option


### PR DESCRIPTION
## Description
Hey all. Came across this one while using the library for the first time (great work btw). I found there's surprisingly little documentation on creating templates in `tabula-py`. There is of course the `Tabula` app, that allows you to export templates based on location coordinates, but I was surprised when digging into the codebase here that only `extraction_method`, `page` and `area` were able to be specified within the template. 

While a little inconvenient specify additional kwargs after providing a template, the larger issue is that this makes it a little restrictive for users when specifying their extraction area, as they're generally locked in to either using coordinates to specify page area, or using % width/height, as they must provide this as a kwarg when calling `read_pdf_with_template`

```python
possible_dfs = tabula.read_pdf_with_template("input.pdf", "template.json", relative_area=True)
```

Hence I'd like to propose a relatively minor QoL change here. Essentially I think it'd be a good idea if we allowed users to specify the `relative_area` option within their template. I'd also be open to unpacking more or all of the possible arguments to `TabulaOption`, though there's some discussion to be had there I think about the usefulness of a certain few (e.g. `password` ) to be mixed-and-matched in the list of templates, and/or the behaviour this would perhaps encourage.

The point that tipped me over the edge into raising this PR, is that `area` and `relative_area` are natively very closely coupled, and they should really be specified together as a pair. Otherwise you end up in a situation where it becomes difficult to share my template with other users if I'm specifying my coordinates in %, as the template doesn't work as a standalone file, and I need to ensure downsteam users are also using the same kwarg overrides as I am.

You could make a similar argument for the extra parameters available within `read_pdf_with_template`, however `relative_area` feels much more pertinent and relevant to using and distributing templates.

## Motivation and Context
I think it would be useful to allow users to mix-and-match coordinate systems here, so that if they're dealing with a set of significantly varying PDFs (as in my case when I was playing with this), they can specify numerous templates and and toggle the relative area within their template config, and use the one that provides the best result.

## How Has This Been Tested?
All the CI checks are passing

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Happy to add tests/docs if we feel we need them. Particularly if we decide to allow full template unpacking.