### PR TITLE
feat: Use jpype instead of subprocess

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,4 +22,6 @@ def lint(session):
 @nox.session
 def tests(session):
     session.install(".[test]")
-    session.run("pytest", "-v")
+    session.run("pytest", "-v", "tests/test_read_pdf_table.py")
+    session.run("pytest", "-v", "tests/test_read_pdf_jar_path.py")
+    session.run("pytest", "-v", "tests/test_read_pdf_silent.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "pandas >= 0.25.3",
   "numpy",
   "distro",
+  "jpype1",
 ]
 dynamic = ["version"]
 
@@ -75,3 +76,7 @@ exclude = [
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+# Disable faulthandler plugin on Windows to prevent spurious console noise
+addopts = "-p no:faulthandler"

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -1,7 +1,6 @@
 """This module is a wrapper of tabula, which enables table extraction from a PDF.
 
-This module extracts tables from a PDF into a pandas DataFrame. Currently, the
-implementation of this module uses subprocess.
+This module extracts tables from a PDF into a pandas DataFrame via jpype.
 
 Instead of importing this module, you can import public interfaces such as
 :func:`read_pdf()`, :func:`read_pdf_with_template()`, :func:`convert_into()`,
@@ -14,7 +13,7 @@ Note:
 Example:
 
     >>> import tabula
-    >>> df = tabula.read_pdf("/path/to/sample.pdf", pages="all")
+    >>> dfs = tabula.read_pdf("/path/to/sample.pdf", pages="all")
 """
 
 import errno

--- a/tests/test_read_pdf_jar_path.py
+++ b/tests/test_read_pdf_jar_path.py
@@ -2,6 +2,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import tabula
 
 
@@ -9,12 +11,11 @@ class TestReadPdfJarPath(unittest.TestCase):
     def setUp(self):
         self.pdf_path = "tests/resources/data.pdf"
 
-    @patch("tabula.io._call_tabula_java")
-    @patch("tabula.io._jar_path")
-    def test_read_pdf_with_jar_path(self, jar_func, mock_fun):
+    @patch("tabula.io.TabulaVm._jar_path")
+    def test_read_pdf_with_jar_path(self, jar_func):
         jar_func.return_value = "/tmp/tabula-java.jar"
 
-        tabula.read_pdf(self.pdf_path, encoding="utf-8")
+        with pytest.raises(ImportError):
+            tabula.read_pdf(self.pdf_path, encoding="utf-8")
         file_name = Path(tabula.io.jpype.getClassPath()).name
         self.assertEqual(file_name, "tabula-java.jar")
-        mock_fun.assert_called_once()

--- a/tests/test_read_pdf_jar_path.py
+++ b/tests/test_read_pdf_jar_path.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import tabula
+
+
+class TestReadPdfJarPath(unittest.TestCase):
+    def setUp(self):
+        self.pdf_path = "tests/resources/data.pdf"
+
+    @patch("tabula.io._call_tabula_java")
+    @patch("tabula.io._jar_path")
+    def test_read_pdf_with_jar_path(self, jar_func, mock_fun):
+        jar_func.return_value = "/tmp/tabula-java.jar"
+
+        tabula.read_pdf(self.pdf_path, encoding="utf-8")
+        file_name = Path(tabula.io.jpype.getClassPath()).name
+        self.assertEqual(file_name, "tabula-java.jar")
+        mock_fun.assert_called_once()

--- a/tests/test_read_pdf_silent.py
+++ b/tests/test_read_pdf_silent.py
@@ -2,6 +2,8 @@ import platform
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 import tabula
 
 
@@ -9,10 +11,10 @@ class TestReadPdfJarPath(unittest.TestCase):
     def setUp(self):
         self.pdf_path = "tests/resources/data.pdf"
 
-    @patch("tabula.io._call_tabula_java")
     @patch("tabula.io.jpype.startJVM")
-    def test_read_pdf_with_silent_true(self, jvm_func, mock_fun):
-        tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
+    def test_read_pdf_with_silent_true(self, jvm_func):
+        with pytest.raises(ImportError):
+            tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
 
         target_args = []
         if platform.system() == "Darwin":
@@ -26,5 +28,3 @@ class TestReadPdfJarPath(unittest.TestCase):
             *target_args,
             convertStrings=False,
         )
-
-        mock_fun.assert_called_once()

--- a/tests/test_read_pdf_silent.py
+++ b/tests/test_read_pdf_silent.py
@@ -1,0 +1,30 @@
+import platform
+import unittest
+from unittest.mock import patch
+
+import tabula
+
+
+class TestReadPdfJarPath(unittest.TestCase):
+    def setUp(self):
+        self.pdf_path = "tests/resources/data.pdf"
+
+    @patch("tabula.io._call_tabula_java")
+    @patch("tabula.io.jpype.startJVM")
+    def test_read_pdf_with_silent_true(self, jvm_func, mock_fun):
+        tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
+
+        target_args = []
+        if platform.system() == "Darwin":
+            target_args += ["-Djava.awt.headless=true"]
+        target_args += [
+            "-Dfile.encoding=UTF8",
+            "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
+            "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog",
+        ]
+        jvm_func.assert_called_once_with(
+            *target_args,
+            convertStrings=False,
+        )
+
+        mock_fun.assert_called_once()

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -1,13 +1,10 @@
 import filecmp
 import json
 import os
-import platform
 import shutil
-import subprocess
 import tempfile
 import unittest
 import uuid
-from unittest.mock import patch
 
 import pandas as pd  # type: ignore
 
@@ -287,33 +284,6 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertEqual(len(dfs), 4)
         self.assertTrue(dfs[0].equals(pd.read_csv(self.expected_csv1)))
 
-    @patch("subprocess.run")
-    @patch("tabula.io._jar_path")
-    def test_read_pdf_with_jar_path(self, jar_func, mock_fun):
-        jar_func.return_value = "/tmp/tabula-java.jar"
-
-        tabula.read_pdf(self.pdf_path, encoding="utf-8")
-
-        target_args = ["java"]
-        if platform.system() == "Darwin":
-            target_args += ["-Djava.awt.headless=true"]
-        target_args += [
-            "-Dfile.encoding=UTF8",
-            "-jar",
-            "/tmp/tabula-java.jar",
-            "--guess",
-            "--format",
-            "JSON",
-            "tests/resources/data.pdf",
-        ]
-        subp_args = {
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "stdin": subprocess.DEVNULL,
-            "check": True,
-        }
-        mock_fun.assert_called_with(target_args, **subp_args)
-
     def test_read_pdf_with_dtype_string(self):
         pdf_path = "tests/resources/data_dtype.pdf"
         expected_csv = "tests/resources/data_dtype_expected.csv"
@@ -360,63 +330,6 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertTrue(
             dfs_template[0].equals(pd.read_csv(template_expected_csv, **pandas_options))
         )
-
-    @patch("subprocess.run")
-    @patch("tabula.io._jar_path")
-    def test_read_pdf_with_silent_false(self, jar_func, mock_fun):
-        jar_func.return_value = "/tmp/tabula-java.jar"
-
-        tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=False)
-
-        target_args = ["java"]
-        if platform.system() == "Darwin":
-            target_args += ["-Djava.awt.headless=true"]
-        target_args += [
-            "-Dfile.encoding=UTF8",
-            "-jar",
-            "/tmp/tabula-java.jar",
-            "--guess",
-            "--format",
-            "JSON",
-            "tests/resources/data.pdf",
-        ]
-        subp_args = {
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "stdin": subprocess.DEVNULL,
-            "check": True,
-        }
-        mock_fun.assert_called_with(target_args, **subp_args)
-
-    @patch("subprocess.run")
-    @patch("tabula.io._jar_path")
-    def test_read_pdf_with_silent_true(self, jar_func, mock_fun):
-        jar_func.return_value = "/tmp/tabula-java.jar"
-
-        tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
-
-        target_args = ["java"]
-        if platform.system() == "Darwin":
-            target_args += ["-Djava.awt.headless=true"]
-        target_args += [
-            "-Dfile.encoding=UTF8",
-            "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
-            "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog",
-            "-jar",
-            "/tmp/tabula-java.jar",
-            "--guess",
-            "--format",
-            "JSON",
-            "--silent",
-            "tests/resources/data.pdf",
-        ]
-        subp_args = {
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "stdin": subprocess.DEVNULL,
-            "check": True,
-        }
-        mock_fun.assert_called_with(target_args, **subp_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Close #352 
Successor of #355 

## Motivation and Context
To reduce JVM launch overhead for each execution.

## How Has This Been Tested?
Unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
