### PR TITLE
chore: add warning about java options

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -184,6 +184,12 @@ No.
 
 Sometimes, you might see a message like `` Jul 17, 2019 10:21:25 AM org.apache.pdfbox.pdmodel.font.PDType1Font WARNING: Using fallback font NimbusSanL-Regu for Univers. Nothing was parsed from this one.`` This error message came from Apache PDFBox which is used under tabula-java, and this is caused by the PDF itself. Neither tabula-py nor tabula-java can't handle the warning itself, except for the silent option that suppresses the warning.
 
+``java_options`` is ignored once ``read_pdf`` or similar funcion is called.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Since jpype doesn't support changing JVM options after the JVM is started, ``java_options`` is ignored once ``read_pdf`` or similar funcion is called. If you want to change JVM options, you need to restart the Python process.
+See also: https://jpype.readthedocs.io/en/latest/api.html#jpype.shutdownJVM
+
+
 I can't figure out accurate extraction with tabula-py. Are there any similar Python libraries?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -66,6 +66,8 @@ def _run(
     global _tabula_vm
     if not _tabula_vm:
         _tabula_vm = TabulaVm(java_options, options.silent)
+    elif java_options:
+        logger.warning("java_options is ignored until rebooting the Python process.")
 
     return _tabula_vm.call_tabula_java(options, path)
 
@@ -151,7 +153,7 @@ def read_pdf(
         encoding (str, optional):
             Encoding type for pandas. Default: ``utf-8``
         java_options (list, optional):
-            Set java options.
+            Set java options. This option will be ignored once JVM is launched.
 
             Example:
                 ``["-Xmx256m"]``
@@ -503,6 +505,7 @@ def read_pdf_with_template(
             Encoding type for pandas. Default is 'utf-8'
         java_options (list, optional):
             Set java options like ``["-Xmx256m"]``.
+            This option will be ignored once JVM is launched.
         user_agent (str, optional):
             Set a custom user-agent when download a pdf from a url. Otherwise
             it uses the default ``urllib.request`` user-agent.
@@ -732,7 +735,7 @@ def convert_into(
             Output format of this function (``csv``, ``json`` or ``tsv``).
             Default: ``csv``
         java_options (list, optional):
-            Set java options
+            Set java options. This option will be ignored once JVM is launched.
 
             Example:
                 ``"-Xmx256m"``.
@@ -866,6 +869,7 @@ def convert_into_by_batch(
             Output format of this function (csv, json or tsv)
         java_options (list, optional):
             Set java options like `-Xmx256m`.
+            This option will be ignored once JVM is launched.
         pages (str, int, `iterable` of `int`, optional):
             An optional values specifying pages to extract from. It allows
             `str`,`int`, `iterable` of :`int`. Default: `1`


### PR DESCRIPTION
Follow up for #356

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add warning and documentation about `java_options` and jpype's shutdownJVM limitation.

## Motivation and Context
Better developer's experience.

## How Has This Been Tested?
Mostly document update.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
