### PR TITLE
chore: suppress warning for tabula-py generated java_options

### DIFF
--- a/tabula/io.py
+++ b/tabula/io.py
@@ -63,10 +63,18 @@ def _run(
     options, as well as an optional path to pass to tabula-java as a regular
     argument to use for any required output sent to stderr.
     """
+    # Ignore some options that are set by tabula-py
+    IGNORED_JAVA_OPTIONS = {
+        "-Djava.awt.headless=true",
+        "-Dfile.encoding=UTF8",
+        "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
+        "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog",
+    }
+
     global _tabula_vm
     if not _tabula_vm:
         _tabula_vm = TabulaVm(java_options, options.silent)
-    elif java_options:
+    elif set(java_options) - IGNORED_JAVA_OPTIONS:
         logger.warning("java_options is ignored until rebooting the Python process.")
 
     return _tabula_vm.call_tabula_java(options, path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Follow up for #357 

## Motivation and Context
tabula-py generated `java_options` can be ignored for jpype warning.

## How Has This Been Tested?
Manual test.

Before

```sh
$  .venv/bin/python -m timeit  'import tabula; tabula.read_pdf_with_template("examples/data.pdf", "examples/data.tabula-template.json")'
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
java_options is ignored until rebooting the Python process.
1 loop, best of 5: 59.1 msec per loop
```

After
```sh
$ .venv/bin/python -m timeit  'import tabula; tabula.read_pdf_with_template("examples/data.pdf", "examples/data.tabula-template.json")'
1 loop, best of 5: 57.3 msec per loop
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
