### PR TITLE
feat: Fall back to subprocess if jpype fails

### DIFF
--- a/tabula/backend.py
+++ b/tabula/backend.py
@@ -1,0 +1,122 @@
+import os
+import subprocess
+from logging import getLogger
+from typing import List, Optional
+
+import jpype
+import jpype.imports
+
+from .errors import JavaNotFoundError
+from .util import TabulaOption
+
+logger = getLogger(__name__)
+
+JAVA_NOT_FOUND_ERROR = (
+    "`java` command is not found from this Python process."
+    "Please ensure Java is installed and PATH is set for `java`"
+)
+TABULA_JAVA_VERSION = "1.0.5"
+JAR_NAME = f"tabula-{TABULA_JAVA_VERSION}-jar-with-dependencies.jar"
+JAR_DIR = os.path.abspath(os.path.dirname(__file__))
+DEFAULT_CONFIG = {"JAR_PATH": os.path.join(JAR_DIR, JAR_NAME)}
+
+
+def jar_path() -> str:
+    return os.environ.get("TABULA_JAR", DEFAULT_CONFIG["JAR_PATH"])
+
+
+class TabulaVm:
+    def __init__(self, java_options: List[str], silent: Optional[bool]) -> None:
+        if not jpype.isJVMStarted():
+            jpype.addClassPath(jar_path())
+
+            # Workaround to enforce the silent option. See:
+            # https://github.com/tabulapdf/tabula-java/issues/231#issuecomment-397281157
+            if silent:
+                java_options.extend(
+                    (
+                        "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
+                        "-Dorg.apache.commons.logging.Log"
+                        "=org.apache.commons.logging.impl.NoOpLog",
+                    )
+                )
+
+            jpype.startJVM(*java_options, convertStrings=False)
+
+        try:
+            import java.lang as lang
+            import technology.tabula as tabula
+            from org.apache.commons.cli import DefaultParser
+
+            self.tabula = tabula
+            self.parser = DefaultParser()
+            self.lang = lang
+        except (ModuleNotFoundError, ImportError) as e:
+            logger.warning(
+                "Error importing jpype dependencies. Fallback to subprocess."
+            )
+            logger.warning(jpype.java.lang.System.getProperty("java.class.path"))
+            logger.warning(e)
+            self.tabula = None
+            self.parse = None
+            self.lang = None
+
+    def call_tabula_java(
+        self, options: TabulaOption, path: Optional[str] = None
+    ) -> str:
+        sb = self.lang.StringBuilder()
+        args = options.build_option_list()
+        if path:
+            args.insert(0, path)
+
+        cmd = self.parser.parse(self.tabula.CommandLineApp.buildOptions(), args)
+        self.tabula.CommandLineApp(sb, cmd).extractTables(cmd)
+        return str(sb.toString())
+
+
+class SubprocessTabula:
+    def __init__(
+        self, java_options: List[str], silent: Optional[bool], encoding: str
+    ) -> None:
+        # Workaround to enforce the silent option. See:
+        # https://github.com/tabulapdf/tabula-java/issues/231#issuecomment-397281157
+        if silent:
+            java_options.extend(
+                (
+                    "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
+                    "-Dorg.apache.commons.logging.Log"
+                    "=org.apache.commons.logging.impl.NoOpLog",
+                )
+            )
+
+        self.java_options = java_options
+        self.encoding = encoding
+
+    def call_tabula_java(
+        self, options: TabulaOption, path: Optional[str] = None
+    ) -> str:
+        args = (
+            ["java"]
+            + self.java_options
+            + ["-jar", jar_path()]
+            + options.build_option_list()
+        )
+        if path:
+            args.append(path)
+
+        try:
+            result = subprocess.run(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.DEVNULL,
+                check=True,
+            )
+            if result.stderr:
+                logger.warning(f"Got stderr: {result.stderr.decode(self.encoding)}")
+            return result.stdout.decode(self.encoding)
+        except FileNotFoundError:
+            raise JavaNotFoundError(JAVA_NOT_FOUND_ERROR)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Error from tabula-java:\n{e.stderr.decode(self.encoding)}\n")
+            raise

--- a/tests/test_read_pdf_jar_path.py
+++ b/tests/test_read_pdf_jar_path.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from subprocess import CalledProcessError
 from unittest.mock import patch
 
 import pytest
@@ -11,11 +12,12 @@ class TestReadPdfJarPath(unittest.TestCase):
     def setUp(self):
         self.pdf_path = "tests/resources/data.pdf"
 
-    @patch("tabula.io.TabulaVm._jar_path")
+    @patch("tabula.backend.jar_path")
     def test_read_pdf_with_jar_path(self, jar_func):
         jar_func.return_value = "/tmp/tabula-java.jar"
 
-        with pytest.raises(ImportError):
+        # Fallback to subprocess
+        with pytest.raises(CalledProcessError):
             tabula.read_pdf(self.pdf_path, encoding="utf-8")
-        file_name = Path(tabula.io.jpype.getClassPath()).name
+        file_name = Path(tabula.backend.jpype.getClassPath()).name
         self.assertEqual(file_name, "tabula-java.jar")

--- a/tests/test_read_pdf_silent.py
+++ b/tests/test_read_pdf_silent.py
@@ -11,9 +11,9 @@ class TestReadPdfJarPath(unittest.TestCase):
     def setUp(self):
         self.pdf_path = "tests/resources/data.pdf"
 
-    @patch("tabula.io.jpype.startJVM")
+    @patch("tabula.backend.jpype.startJVM")
     def test_read_pdf_with_silent_true(self, jvm_func):
-        with pytest.raises(ImportError):
+        with pytest.raises(RuntimeError):
             tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
 
         target_args = []

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -36,6 +36,12 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertTrue(len(df), 1)
         self.assertTrue(isinstance(df[0], pd.DataFrame))
 
+    def test_read_pdf_with_force_subprocess(self):
+        df = tabula.read_pdf(self.pdf_path, stream=True, force_subprocess=True)
+        self.assertTrue(len(df), 1)
+        self.assertTrue(isinstance(df[0], pd.DataFrame))
+        self.assertTrue(df[0].equals(pd.read_csv(self.expected_csv1)))
+
     def test_read_pdf_into_json(self):
         expected_json = "tests/resources/data_1.json"
         json_data = tabula.read_pdf(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
jpype triggers weird errors in specific environments https://github.com/chezou/tabula-py/issues/352#issuecomment-1730791540
This patch allows to fallback to subprocess when jpype import fails.

Bonus: add `force_subprocess` option to enforce using subprocess.

## Motivation and Context
To add workaround for jpype issue.

## How Has This Been Tested?
unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
