### PR TITLE
Make jpype optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Ensure you have a Java runtime and set the PATH for it.
 pip install tabula-py
 ```
 
+If you want to leverage faster execution with jpype, install with `jpype` extra.
+
+```sh
+pip install tabula-py[jpype]
+```
+
 ### Example
 
 tabula-py enables you to extract tables from a PDF into a DataFrame, or a JSON. It can also extract tables from a PDF and save the file as a CSV, a TSV, or a JSON.  

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,6 +26,12 @@ You can install tabula-py from PyPI with ``pip`` command.
    pip install tabula-py
 
 
+If you want to leverage faster execution with jpype, install with `jpype` extra.
+
+.. code-block:: bash
+
+   pip install tabula-py[jpype]
+
 .. Note::
     conda recipe on conda-forge is not maintained by us.
     We recommend installing via ``pip`` to use the latest version of tabula-py.

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,8 +20,30 @@ def lint(session):
 
 
 @nox.session
-def tests(session):
+@nox.parametrize(
+    "python,jpype",
+    [
+        ("3.8", True),
+        ("3.9", True),
+        ("3.10", True),
+        ("3.11", True),
+        # ("3.12", False),
+    ],
+)
+def tests(session, jpype):
+    if jpype:
+        tests_with_jpype(session)
+    else:
+        tests_without_jpype(session)
+
+
+def tests_without_jpype(session):
     session.install(".[test]")
+    session.run("pytest", "-v", "tests/test_read_pdf_table.py")
+
+
+def tests_with_jpype(session):
+    session.install(".[jpype,test]")
     session.run("pytest", "-v", "tests/test_read_pdf_table.py")
     session.run("pytest", "-v", "tests/test_read_pdf_jar_path.py")
     session.run("pytest", "-v", "tests/test_read_pdf_silent.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ dependencies = [
   "pandas >= 0.25.3",
   "numpy",
   "distro",
-  "jpype1",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+jpype = ["jpype1"]
 dev = [
   "pytest",
   "flake8",

--- a/tests/test_read_pdf_jar_path.py
+++ b/tests/test_read_pdf_jar_path.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from unittest.mock import patch
 
+import jpype
 import pytest
 
 import tabula
@@ -19,5 +20,5 @@ class TestReadPdfJarPath(unittest.TestCase):
         # Fallback to subprocess
         with pytest.raises(CalledProcessError):
             tabula.read_pdf(self.pdf_path, encoding="utf-8")
-        file_name = Path(tabula.backend.jpype.getClassPath()).name
+        file_name = Path(jpype.getClassPath()).name
         self.assertEqual(file_name, "tabula-java.jar")

--- a/tests/test_read_pdf_silent.py
+++ b/tests/test_read_pdf_silent.py
@@ -2,8 +2,6 @@ import platform
 import unittest
 from unittest.mock import patch
 
-import pytest
-
 import tabula
 
 
@@ -11,10 +9,9 @@ class TestReadPdfJarPath(unittest.TestCase):
     def setUp(self):
         self.pdf_path = "tests/resources/data.pdf"
 
-    @patch("tabula.backend.jpype.startJVM")
+    @patch("jpype.startJVM")
     def test_read_pdf_with_silent_true(self, jvm_func):
-        with pytest.raises(RuntimeError):
-            tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
+        tabula.read_pdf(self.pdf_path, encoding="utf-8", silent=True)
 
         target_args = []
         if platform.system() == "Darwin":


### PR DESCRIPTION
## Description
To approach #368, make jpype installation extra dependency.

## Motivation and Context
Since jpype hasn't supported Python 3.12 yet, it'd be better to make it optional to work tabula-py on Python 3.12.

## How Has This Been Tested?
Unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
