### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -26,6 +26,7 @@ jobs:
           3.9
           3.10
           3.11
+          3.12
     - name: Install dependencies and test
       run: |
         python -m pip install --upgrade pip

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def lint(session):
         ("3.9", True),
         ("3.10", True),
         ("3.11", True),
-        # ("3.12", False),
+        ("3.12", False),
     ],
 )
 def tests(session, jpype):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Topic :: Text Processing :: General",
   "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Description
Close #368 

Note that jpype doesn't support Python 3.12 yet, the tabula-py unit test runs without jpype on Python 3.12.

## Motivation and Context
To support Python 3.12 without waiting jpype supports.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
