### PR TITLE
Set encoding on SubprocessTabula initialization

### DIFF
--- a/tabula/backend.py
+++ b/tabula/backend.py
@@ -89,6 +89,10 @@ class SubprocessTabula:
                 )
             )
 
+        if encoding == "utf-8":
+            if not any("file.encoding" in opt for opt in java_options):
+                java_options += ["-Dfile.encoding=UTF8"]
+
         self.java_options = java_options
         self.encoding = encoding
 

--- a/tabula/backend.py
+++ b/tabula/backend.py
@@ -89,10 +89,6 @@ class SubprocessTabula:
                 )
             )
 
-        if encoding == "utf-8":
-            if not any("file.encoding" in opt for opt in java_options):
-                java_options += ["-Dfile.encoding=UTF8"]
-
         self.java_options = java_options
         self.encoding = encoding
 

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -391,10 +391,6 @@ def read_pdf(
         if not any("java.awt.headless" in opt for opt in java_options):
             java_options += ["-Djava.awt.headless=true"]
 
-    if encoding == "utf-8":
-        if not any("file.encoding" in opt for opt in java_options):
-            java_options += ["-Dfile.encoding=UTF8"]
-
     path, temporary = localize_file(input_path, user_agent, use_raw_url=use_raw_url)
 
     if not os.path.exists(path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When calling `read_pdf()` after `convert_into()` with subprocess, `-Dfile.encoding` won't be set. This patch fixes the error.

## Motivation and Context
Written in the description.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
