### PR TITLE
Update encoding everytime when SubprocessTabule is initialized

### DIFF
--- a/tabula/backend.py
+++ b/tabula/backend.py
@@ -92,6 +92,20 @@ class SubprocessTabula:
         self.java_options = java_options
         self.encoding = encoding
 
+    def update_encoding(
+        self, encoding: str, java_options: List[str], silent: Optional[bool]
+    ) -> None:
+        self.encoding = encoding
+        self.java_options = java_options
+        if silent:
+            self.java_options.extend(
+                (
+                    "-Dorg.slf4j.simpleLogger.defaultLogLevel=off",
+                    "-Dorg.apache.commons.logging.Log"
+                    "=org.apache.commons.logging.impl.NoOpLog",
+                )
+            )
+
     def call_tabula_java(
         self, options: TabulaOption, path: Optional[str] = None
     ) -> str:

--- a/tabula/io.py
+++ b/tabula/io.py
@@ -76,6 +76,10 @@ def _run(
             _tabula_vm = SubprocessTabula(
                 java_options=java_options, silent=options.silent, encoding=encoding
             )
+    elif isinstance(_tabula_vm, SubprocessTabula):
+        _tabula_vm.update_encoding(
+            encoding=encoding, java_options=java_options, silent=options.silent
+        )
     elif set(java_options) - IGNORED_JAVA_OPTIONS:
         logger.warning("java_options is ignored until rebooting the Python process.")
 

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -41,6 +41,9 @@ class TestReadPdfTable(unittest.TestCase):
         self.assertTrue(len(df), 1)
         self.assertTrue(isinstance(df[0], pd.DataFrame))
         self.assertTrue(df[0].equals(pd.read_csv(self.expected_csv1)))
+        self.assertTrue(tabula.io._tabula_vm.encoding, "utf-8")
+        tabula.read_pdf(self.pdf_path, stream=True, encoding="cp932")
+        self.assertTrue(tabula.io._tabula_vm.encoding, "cp932")
 
     def test_read_pdf_into_json(self):
         expected_json = "tests/resources/data_1.json"


### PR DESCRIPTION
## Description
Enforce updating `encoding` and `java_process` options when `SubprocessTabula` is used.

## Motivation and Context
This is an improvement that allows the flexibility that was available before jpype support.
Hope to fix https://github.com/chezou/tabula-py/issues/377 as well.

## How Has This Been Tested?
unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
