### PR TITLE
Allow columns option to be more generic type than list (Fixes #389)

### DIFF
--- a/tabula/util.py
+++ b/tabula/util.py
@@ -9,7 +9,7 @@ import platform
 import shlex
 from dataclasses import dataclass
 from logging import getLogger
-from typing import IO, Iterable, List, Optional, Union, cast
+from typing import IO, Iterable, List, Optional, Sequence, Union, cast
 
 logger = getLogger(__name__)
 
@@ -115,8 +115,9 @@ class TabulaOption:
             Password to decrypt document. Default: empty
         silent (bool, optional):
             Suppress all stderr output.
-        columns (iterable, optional):
-            X coordinates of column boundaries.
+        columns (Sequence, optional):
+            X coordinates of column boundaries. Must be sorted and of a datatype that
+            preserves order, e.g. tuple or list
 
             Example:
                 ``[10.1, 20.2, 30.3]``
@@ -147,7 +148,7 @@ class TabulaOption:
     stream: bool = False
     password: Optional[str] = None
     silent: Optional[bool] = None
-    columns: Optional[Iterable[float]] = None
+    columns: Optional[Sequence[float]] = None
     relative_columns: bool = False
     format: Optional[str] = None
     batch: Optional[str] = None
@@ -235,7 +236,7 @@ class TabulaOption:
             __options += ["--outfile", self.output_path]
 
         if self.columns:
-            if self.columns != sorted(self.columns):
+            if list(self.columns) != sorted(self.columns):
                 raise ValueError("columns option should be sorted")
 
             __columns = _format_with_relative(self.columns, self.relative_columns)

--- a/tests/test_read_pdf_table.py
+++ b/tests/test_read_pdf_table.py
@@ -91,6 +91,15 @@ class TestReadPdfTable(unittest.TestCase):
             )[0].equals(pd.read_csv(expected_csv))
         )
 
+    def test_read_pdf_with_tuple_columns(self):
+        pdf_path = "tests/resources/campaign_donors.pdf"
+        expected_csv = "tests/resources/campaign_donors.csv"
+        self.assertTrue(
+            tabula.read_pdf(
+                pdf_path, columns=(47, 147, 256, 310, 375, 431, 504), guess=False
+            )[0].equals(pd.read_csv(expected_csv))
+        )
+
     def test_read_pdf_with_relative_columns(self):
         pdf_path = "tests/resources/campaign_donors.pdf"
         expected_csv = "tests/resources/campaign_donors.csv"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Convert columns parameter to a list prior to checking it is identical to a sorted list, so it will now work, e.g. with a tuple.
Changed the type hint from Iterable to Sequence to reflect the fact that that it must have a consistent order. (Sequence doesn't formally guarantee this, but it is implicit in the definition.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #389.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
nox has been run. Although errors were found, these were the same errors as in master, and were unrelated to this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
