### PR TITLE
Add test for Python 3.13 with jpype

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,8 +24,8 @@ def lint(session):
         ("3.10", True),
         ("3.11", True),
         ("3.12", True),
-        ("3.13", False),  # jpype does not support Python 3.13 yet
-        # ("3.13", True),
+        ("3.13", False),
+        ("3.13", True),
     ],
 )
 def tests(session, jpype):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To ensure jpype supports Python 3.13 now.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I read [the contributing document](https://tabula-py.readthedocs.io/en/latest/contributing.html).
- [x] My code follows the code style of this project with running linter.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
